### PR TITLE
fix: pin to tomcat version without mitigations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9.0
+FROM tomcat:9.0.59
 
 ADD src/ /helloworld/src
 ADD pom.xml /helloworld


### PR DESCRIPTION
9.0 would otherwise pull the newly minted 9.0.62 tomcat version with mitigations for this CVE.